### PR TITLE
removed extra comma

### DIFF
--- a/iam_role_policy.json
+++ b/iam_role_policy.json
@@ -21,7 +21,7 @@
                 "rds:DescribeDBClusterSnapshots",
                 "rds:DeleteDBClusterSnapshot",
                 "rds:CopyDBClusterSnapshot",
-                "rds:DescribeDBClusters",
+                "rds:DescribeDBClusters"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
extra comma causes the following error when pressing "review policy": "This policy contains the following JSON error: Unexpected token ] in JSON at position 769"